### PR TITLE
Prevent unwanted line breaks in the terminal.

### DIFF
--- a/panel/app.css
+++ b/panel/app.css
@@ -122,6 +122,7 @@ body, html{
   border-width: 3px 5px;
   float: none;
   -webkit-user-select: all;
+  white-space: pre;
 }
 
 .terminal a{


### PR DESCRIPTION
At least for macs, monospace fonts seem to offer line-break opportunities for hyphens. This style prevents the break, but still breaks for long lines and new lines.

Merging this will automatically close #10 and #12.
