### PR TITLE
several bug fixes

### DIFF
--- a/backend/bin/devtools-terminal
+++ b/backend/bin/devtools-terminal
@@ -66,7 +66,7 @@ function NativeMessagingAPI(){
       event: event,
       data: data
     });
-    var length = msg.length;
+    var length = new Buffer(msg).length;
     var length_str = new Buffer(4);
     length_str.writeInt32LE(length, 0);
     process.stdout.write(length_str);
@@ -277,7 +277,7 @@ if(options['install']){
       var user;
       if(user = auth(handshakeData.query.auth)){
         handshakeData.user = user;
-        return callback(null, true);      
+        return callback(null, true);
       }else{
         return callback('auth error', false);
       }
@@ -308,7 +308,7 @@ if(options['install']){
     });
 
     term.on('close', function(){
-      socket.disconnect();
+      socket && socket.disconnect();
     })
 
     socket.on('data', function(data) {


### PR DESCRIPTION
1. fix non-ascii characters length. Useful if the terminal output contains fancy symbols or non English. fix #31 
2. fix client-socket close. If one client exits, the server socket will not crash. This enables multiple terminal tabs under socket mode.
3. remove trailing space. Please pardon my revise, I hope this revise follows your coding style
